### PR TITLE
C++14 support (replacing C++17-only features)

### DIFF
--- a/include/agl/Utils/aglResCommon.h
+++ b/include/agl/Utils/aglResCommon.h
@@ -2,7 +2,6 @@
 
 #include <basis/seadRawPrint.h>
 #include <prim/seadBitUtil.h>
-#include <string_view>
 
 namespace agl {
 

--- a/src/Utils/aglParameter.cpp
+++ b/src/Utils/aglParameter.cpp
@@ -114,8 +114,8 @@ bool ParameterBase::isSafeType(ParameterType type) const {
         {ParameterType::String64, ParameterType::String256},
     };
 
-    for (const auto [t1, t2] : pairs) {
-        if (type == t1 && getParameterType() == t2)
+    for (const auto pair : pairs) {
+        if (type == pair.first && getParameterType() == pair.second)
             return true;
     }
 


### PR DESCRIPTION
To support `clang-3.9.1` for building Super Mario Odyssey, `C++17` features have to be dropped. Here, this results in two changes:
1. Removing an unused `#include` from `include/agl/Utils/aglResCommon.h`
2. Replacing a structured binding declaration from `src/Utils/aglParameter.cpp`, resulting in the `pair` being stored in a single variable instead of auto-assigning it to two separate variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/1)
<!-- Reviewable:end -->
