### PR TITLE
Start GPU memory management reimplementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ add_library(agl OBJECT
   include/agl/Utils/aglParameterStringMgr.h
   include/agl/Utils/aglResCommon.h
   include/agl/Utils/aglResParameter.h
+  include/agl/detail/aglGPUMemBlockMgr.h
+  include/agl/driver/aglGraphicsDriverMgr.h
+  include/agl/driver/aglNVNMgr.h
+  include/agl/aglGPUCommon.hpp
+  include/agl/aglGPUMemBlock.hpp
   src/Utils/aglAtomicPtrArray.cpp
   src/Utils/aglParameter.cpp
   src/Utils/aglParameterIO.cpp
@@ -19,6 +24,10 @@ add_library(agl OBJECT
   src/Utils/aglParameterStringMgr.cpp
   src/Utils/aglResCommon.cpp
   src/Utils/aglResParameter.cpp
+  src/detail/aglGPUMemBlockMgr.cpp
+  src/driver/aglGraphicsDriverMgr.cpp
+  src/driver/aglNVNMgr.cpp
+  src/aglGPUMemBlock.cpp
 )
 
 target_compile_options(agl PRIVATE -fno-exceptions)

--- a/include/agl/aglGPUCommon.hpp
+++ b/include/agl/aglGPUCommon.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace agl {
+enum class MemoryAttribute : u32 {
+    Default = 0,
+    _00 = 1 << 0,
+    _01 = 1 << 1,
+    CompressibleMemory = 1 << 2,
+    CpuCached = 1 << 3,
+    _04 = 1 << 4,
+    // PHYSICAL, no CPU and GPU access.
+    MemoryReserved = 1 << 7,
+    GpuCached = 1 << 8,
+
+    // TODO: More?
+};
+
+struct GPUMemVoidAddr {
+    // FIXME: what are thoses?
+    u64 _0;
+    u64 _8;
+    u64 mAddress;
+
+    u64 getGPUMemBlock() const { return mAddress; }
+};
+
+}  // namespace agl

--- a/include/agl/aglGPUMemBlock.hpp
+++ b/include/agl/aglGPUMemBlock.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <heap/seadDisposer.h>
+#include <hostio/seadHostIONode.h>
+#include <math/seadMathCalcCommon.h>
+#include <prim/seadTypedBitFlag.h>
+#include <thread/seadCriticalSection.h>
+#include "aglGPUCommon.hpp"
+
+namespace agl {
+
+namespace detail {
+class MemoryPool;
+class MemoryPoolHeap;
+};  // namespace detail
+
+class GPUMemBlockBase {
+public:
+    GPUMemBlockBase(sead::Heap* p_heap);
+    virtual ~GPUMemBlockBase();
+
+    void clear();
+    void freeBuffer();
+    void free();
+    void allocBuffer_(u64, sead::Heap*, s32, MemoryAttribute);
+    bool tryAllocBuffer_(u64, sead::Heap*, s32, MemoryAttribute);
+    void setBuffer_(u64, void*, void*, MemoryAttribute);
+    void setVirtual_(u64, sead::Heap*, MemoryAttribute, GPUMemVoidAddr, s32);
+    void addList(GPUMemBlockBase*);
+    void setMemoryPool(void*, u64, detail::MemoryPool*);
+    void setMemoryPoolHeap(void*, u64, detail::MemoryPoolHeap*);
+    u64 getByteOffset() const;
+    u64 getMemoryPoolType() const;
+
+    // TODO: the rest of the methods...
+
+private:
+    void* mMemoryBuffer;
+    u64 mMemoryBufferSize;
+    detail::MemoryPool* mpMemoryPool;
+    detail::MemoryPoolHeap* mMemoryPoolHeap;
+    uint8_t mFlags;
+    GPUMemBlockBase* mpTail;
+};
+
+static_assert(sizeof(GPUMemBlockBase) == 0x38);
+
+}  // namespace agl

--- a/include/agl/aglGPUMemBlock.hpp
+++ b/include/agl/aglGPUMemBlock.hpp
@@ -13,11 +13,11 @@ namespace agl {
 namespace detail {
 class MemoryPool;
 class MemoryPoolHeap;
-};  // namespace detail
+}  // namespace detail
 
 class GPUMemBlockBase {
 public:
-    GPUMemBlockBase(sead::Heap* p_heap);
+    explicit GPUMemBlockBase(sead::Heap* p_heap);
     virtual ~GPUMemBlockBase();
 
     void clear();

--- a/include/agl/detail/aglGPUMemBlockMgr.h
+++ b/include/agl/detail/aglGPUMemBlockMgr.h
@@ -14,9 +14,9 @@ namespace agl::detail {
 
 typedef sead::BitFlag32 MemoryPoolDriverBitFlag;
 
-const s32 VALID_POOL_TYPE_VALUE = -1;
-const s32 cGPUAccessMask = 0xF0000000;
-const u64 cGPUPhysicalMemorySizeAlignment = 0x1000;
+constexpr s32 VALID_POOL_TYPE_VALUE = -1;
+constexpr s32 cGPUAccessMask = 0xF0000000;
+constexpr u64 cGPUPhysicalMemorySizeAlignment = 0x1000;
 
 class MemoryPoolType : MemoryPoolDriverBitFlag {
 public:
@@ -46,10 +46,10 @@ private:
 
 static_assert(sizeof(MemoryPool) == 0x108);
 
-class GPUMemBlockMgrHeapEx : public sead::hostio::Node, sead::IDisposer {
+class GPUMemBlockMgrHeapEx : public sead::hostio::Node, public sead::IDisposer {
 public:
     GPUMemBlockMgrHeapEx(sead::Heap* p_heap);
-    virtual ~GPUMemBlockMgrHeapEx();
+    ~GPUMemBlockMgrHeapEx() override;
 
     void finalize();
 

--- a/include/agl/detail/aglGPUMemBlockMgr.h
+++ b/include/agl/detail/aglGPUMemBlockMgr.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <agl/aglGPUCommon.hpp>
+#include <container/seadPtrArray.h>
+#include <heap/seadDisposer.h>
+#include <hostio/seadHostIONode.h>
+#include <math/seadMathCalcCommon.h>
+#include <nvn/nvn_types.h>
+#include <prim/seadBitFlag.h>
+#include <prim/seadTypedBitFlag.h>
+#include <thread/seadCriticalSection.h>
+
+namespace agl::detail {
+
+typedef sead::BitFlag32 MemoryPoolDriverBitFlag;
+
+const s32 VALID_POOL_TYPE_VALUE = -1;
+const s32 cGPUAccessMask = 0xF0000000;
+const u64 cGPUPhysicalMemorySizeAlignment = 0x1000;
+
+class MemoryPoolType : MemoryPoolDriverBitFlag {
+public:
+    MemoryPoolType() : MemoryPoolDriverBitFlag() {}
+    MemoryPoolType(s32 p_value) : MemoryPoolDriverBitFlag(p_value) {}
+
+    MemoryPoolType convert(MemoryAttribute attribute);
+
+    bool IsValid() const { return (*this & cValidPoolType) == cValidPoolType; }
+
+    void MarkValid() { *this = *this | cValidPoolType; }
+
+private:
+    static const MemoryPoolType cInvalidPoolType;
+    static const MemoryPoolType cValidPoolType;
+};
+
+class MemoryPool {
+public:
+    MemoryPool();
+
+private:
+    NVNmemoryPool mDriverPool;
+    MemoryPoolType mMemoryType;
+    uint32_t idk;
+};
+
+static_assert(sizeof(MemoryPool) == 0x108);
+
+class GPUMemBlockMgrHeapEx : public sead::hostio::Node, sead::IDisposer {
+public:
+    GPUMemBlockMgrHeapEx(sead::Heap* p_heap);
+    virtual ~GPUMemBlockMgrHeapEx();
+
+    void finalize();
+
+private:
+    s32 mAllowSharing;
+    void* m08;
+    void* m10;
+    sead::CriticalSection mCS;
+};
+
+static_assert(sizeof(GPUMemBlockMgrHeapEx) == 0x80);
+
+enum class GPUMemBlockMgrFlags : u8 {
+    MemoryPoolRelated = 1 << 0,
+    EnablePoolSharing = 1 << 1,
+    Debug = 1 << 2
+};
+
+class GPUMemBlockMgr : public sead::hostio::Node {
+public:
+    SEAD_SINGLETON_DISPOSER(GPUMemBlockMgr)
+    GPUMemBlockMgr();
+    virtual ~GPUMemBlockMgr();
+
+    void initialize(sead::Heap* heap1, sead::Heap* heap2);
+    void enableSharedMemoryPool(bool enabled);
+    static u64 calcGPUMemorySize(u64 userSize);
+    static s32 calcGPUMemoryAlignment(s32 userAlignment);
+
+#ifdef SEAD_DEBUG
+    void listenPropertyEvent(const sead::hostio::PropertyEvent* event) override;
+    void genMessage(sead::hostio::Context* context) override;
+#endif
+
+private:
+    GPUMemBlockMgrHeapEx* findGPUMemBlockMgrHeapEx_(sead::Heap* p_heap, int* p_outIndex);
+
+    sead::CriticalSection mCS;
+    sead::PtrArray<GPUMemBlockMgrHeapEx> mMngrHeaps;
+    size_t mMinBlockSize;
+    sead::TypedBitFlag<GPUMemBlockMgrFlags> mFlags;
+};
+
+static_assert(sizeof(GPUMemBlockMgr) == 0x88);
+
+}  // namespace agl::detail

--- a/include/agl/detail/aglGPUMemBlockMgr.h
+++ b/include/agl/detail/aglGPUMemBlockMgr.h
@@ -69,8 +69,8 @@ enum class GPUMemBlockMgrFlags : u8 {
 };
 
 class GPUMemBlockMgr : public sead::hostio::Node {
-public:
     SEAD_SINGLETON_DISPOSER(GPUMemBlockMgr)
+public:
     GPUMemBlockMgr();
     virtual ~GPUMemBlockMgr();
 

--- a/include/agl/driver/aglGraphicsDriverMgr.h
+++ b/include/agl/driver/aglGraphicsDriverMgr.h
@@ -11,8 +11,8 @@ class DisplayList;
 namespace agl::driver {
 
 class GraphicsDriverMgr : public sead::hostio::Node {
-public:
     SEAD_SINGLETON_DISPOSER(GraphicsDriverMgr)
+public:
     GraphicsDriverMgr();
     virtual ~GraphicsDriverMgr();
 

--- a/include/agl/driver/aglGraphicsDriverMgr.h
+++ b/include/agl/driver/aglGraphicsDriverMgr.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <heap/seadDisposer.h>
+#include <hostio/seadHostIONode.h>
+
+namespace agl {
+class DrawContext;
+class DisplayList;
+}  // namespace agl
+
+namespace agl::driver {
+
+class GraphicsDriverMgr : public sead::hostio::Node {
+public:
+    SEAD_SINGLETON_DISPOSER(GraphicsDriverMgr)
+    GraphicsDriverMgr();
+    virtual ~GraphicsDriverMgr();
+
+    void waitDrawDone() const;
+    void dumpInfo() const;
+    void setPointLimits(agl::DrawContext* draw_context, float min, float max) const;
+    void setPointSize(agl::DrawContext* draw_context, float point_size) const;
+    void setLineWidth(agl::DrawContext* draw_context, float line_width) const;
+
+    agl::DisplayList* getDefaultCommandBuffer();
+
+#ifdef SEAD_DEBUG
+    void listenPropertyEvent(const sead::hostio::PropertyEvent* event) override;
+    void genMessage(sead::hostio::Context* context) override;
+#endif
+
+protected:
+    void initialize_(sead::Heap p_heap);
+
+private:
+    agl::DisplayList* mDefaultCommandBuffer;
+    void* _30;
+};
+
+static_assert(sizeof(GraphicsDriverMgr) == 0x38);
+
+}  // namespace agl::driver

--- a/include/agl/driver/aglNVNMgr.h
+++ b/include/agl/driver/aglNVNMgr.h
@@ -7,10 +7,9 @@
 namespace agl::driver {
 
 class NVNMgr : public GraphicsDriverMgr {
-public:
     // TODO: This is wrong and should actually touch the GraphicsDriverMgr implementation
     SEAD_SINGLETON_DISPOSER(NVNMgr)
-
+public:
     NVNMgr();
     ~NVNMgr() override;
 

--- a/include/agl/driver/aglNVNMgr.h
+++ b/include/agl/driver/aglNVNMgr.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <heap/seadDisposer.h>
+#include <hostio/seadHostIONode.h>
+#include "agl/driver/aglGraphicsDriverMgr.h"
+
+namespace agl::driver {
+
+class NVNMgr : GraphicsDriverMgr {
+public:
+    // TODO: This is wrong and should actually touch the GraphicsDriverMgr implementation
+    SEAD_SINGLETON_DISPOSER(NVNMgr)
+
+    NVNMgr();
+    virtual ~NVNMgr();
+
+private:
+};
+
+// TODO: need sead::Graphics reversing...
+// static_assert(sizeof(NVNMgr) == 0x548);
+
+};  // namespace agl::driver

--- a/include/agl/driver/aglNVNMgr.h
+++ b/include/agl/driver/aglNVNMgr.h
@@ -6,13 +6,13 @@
 
 namespace agl::driver {
 
-class NVNMgr : GraphicsDriverMgr {
+class NVNMgr : public GraphicsDriverMgr {
 public:
     // TODO: This is wrong and should actually touch the GraphicsDriverMgr implementation
     SEAD_SINGLETON_DISPOSER(NVNMgr)
 
     NVNMgr();
-    virtual ~NVNMgr();
+    ~NVNMgr() override;
 
 private:
 };

--- a/src/aglGPUMemBlock.cpp
+++ b/src/aglGPUMemBlock.cpp
@@ -1,0 +1,1 @@
+#include "agl/aglGPUMemBlock.hpp"

--- a/src/detail/aglGPUMemBlockMgr.cpp
+++ b/src/detail/aglGPUMemBlockMgr.cpp
@@ -1,0 +1,55 @@
+#include "agl/detail/aglGPUMemBlockMgr.h"
+
+namespace agl::detail {
+const MemoryPoolType MemoryPoolType::cInvalidPoolType(0);
+const MemoryPoolType MemoryPoolType::cValidPoolType(VALID_POOL_TYPE_VALUE);
+
+SEAD_SINGLETON_DISPOSER_IMPL(GPUMemBlockMgr)
+
+GPUMemBlockMgr::GPUMemBlockMgr() {
+    mMinBlockSize = cGPUPhysicalMemorySizeAlignment;
+    mFlags = GPUMemBlockMgrFlags::EnablePoolSharing;
+}
+
+GPUMemBlockMgr::~GPUMemBlockMgr() {
+    mMngrHeaps.freeBuffer();
+}
+
+void GPUMemBlockMgr::initialize(sead::Heap* heap1, sead::Heap* heap2) {
+    mMngrHeaps.allocBuffer(0x1000, heap1);
+    mMngrHeaps.clear();
+}
+
+void GPUMemBlockMgr::enableSharedMemoryPool(bool enabled) {
+    mFlags.change(GPUMemBlockMgrFlags::EnablePoolSharing, enabled);
+}
+
+u64 GPUMemBlockMgr::calcGPUMemorySize(u64 userSize) {
+    return sead::MathSizeT::roundUp(userSize, cGPUPhysicalMemorySizeAlignment);
+}
+
+s32 GPUMemBlockMgr::calcGPUMemoryAlignment(s32 userAlignment) {
+    return sead::Mathi::roundUpPow2(sead::Mathi::abs(userAlignment),
+                                    cGPUPhysicalMemorySizeAlignment) *
+           sead::Mathi::sign(userAlignment);
+}
+
+GPUMemBlockMgrHeapEx* GPUMemBlockMgr::findGPUMemBlockMgrHeapEx_(sead::Heap* p_heap,
+                                                                int* p_outIndex) {
+    SEAD_ASSERT(p_heap != nullptr);
+
+    if (mMngrHeaps.isEmpty()) {
+        return nullptr;
+    }
+
+    // TODO
+    return nullptr;
+}
+
+GPUMemBlockMgrHeapEx::GPUMemBlockMgrHeapEx(sead::Heap* p_heap) {
+    mAllowSharing = 1;
+    m08 = nullptr;
+    m10 = nullptr;
+}
+
+}  // namespace agl::detail

--- a/src/driver/aglGraphicsDriverMgr.cpp
+++ b/src/driver/aglGraphicsDriverMgr.cpp
@@ -8,5 +8,5 @@ GraphicsDriverMgr::GraphicsDriverMgr() {
     _30 = nullptr;
 }
 
-GraphicsDriverMgr::~GraphicsDriverMgr() {}
+GraphicsDriverMgr::~GraphicsDriverMgr() = default;
 }  // namespace agl::driver

--- a/src/driver/aglGraphicsDriverMgr.cpp
+++ b/src/driver/aglGraphicsDriverMgr.cpp
@@ -1,0 +1,12 @@
+#include "agl/driver/aglGraphicsDriverMgr.h"
+
+namespace agl::driver {
+SEAD_SINGLETON_DISPOSER_IMPL(GraphicsDriverMgr)
+
+GraphicsDriverMgr::GraphicsDriverMgr() {
+    mDefaultCommandBuffer = nullptr;
+    _30 = nullptr;
+}
+
+GraphicsDriverMgr::~GraphicsDriverMgr() {}
+}  // namespace agl::driver

--- a/src/driver/aglNVNMgr.cpp
+++ b/src/driver/aglNVNMgr.cpp
@@ -1,0 +1,6 @@
+#include "agl/driver/aglNVNMgr.h"
+
+namespace agl::driver {
+// TODO: This is wrong and should actually touch the GraphicsDriverMgr implementation
+SEAD_SINGLETON_DISPOSER_IMPL(NVNMgr)
+}  // namespace agl::driver


### PR DESCRIPTION
This is my early attempt at reimplementing it, a lot is still missing of course.
As agl has deep circular dependencies with sead, it should be noted that sead graphics side needs to be reversed more before making mew progress on agl detail and driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/6)
<!-- Reviewable:end -->
