### PR TITLE
Add stubs for TextureDataSerializer and reserveCaptureWithDebugHeap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(agl OBJECT
 
   include/agl/pfx/aglBloom.h
   include/agl/pfx/aglDepthOfField.h
+  
+  include/agl/texture/aglTextureDataSerializer.h
 
   include/agl/utl/aglAtomicPtrArray.h
   include/agl/utl/aglParameter.h
@@ -33,6 +35,7 @@ add_library(agl OBJECT
   include/agl/utl/aglParameterStringMgr.h
   include/agl/utl/aglResCommon.h
   include/agl/utl/aglResParameter.h
+  include/agl/utl/aglScreenShotMgr.h
 
   src/aglGPUMemBlock.cpp
 

--- a/include/agl/texture/aglTextureDataSerializer.h
+++ b/include/agl/texture/aglTextureDataSerializer.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace agl {
+
+// TODO
+class TextureDataSerializerTGA {
+public:
+    enum class TGAFormat {
+        _1 = 1,
+    };
+};
+
+} // namespace agl

--- a/include/agl/utl/aglScreenShotMgr.h
+++ b/include/agl/utl/aglScreenShotMgr.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <heap/seadDisposer.h>
+#include "agl/texture/aglTextureDataInitializer.h"
+
+namespace agl::utl {
+
+// TODO
+class ScreenShotMgr {
+
+    SEAD_SINGLETON_DISPOSER(ScreenShotMgr)
+    ScreenShotMgr() = default;
+    virtual ~ScreenShotMgr();
+
+public:
+    void reserveCaptureWithDebugHeap(bool unk, agl::TextureDataSerializerTGA::TGAFormat format, const sead::SafeString&, bool unk2);
+};
+	
+}  // namespace agl::utl


### PR DESCRIPTION
These are required by VideoRecorder in BOTW
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/7)
<!-- Reviewable:end -->
