### PR TITLE
Add linting workflow

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,0 +1,11 @@
+name: lint_pr
+on: [push, pull_request]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.15
+      with:
+        source: "include src"
+        clangFormatVersion: 12


### PR DESCRIPTION
Running `clang-format` for each PR and on each commit should help enforcing a better structure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/11)
<!-- Reviewable:end -->
