### PR TITLE
detail: Add aglShaderHolder.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(agl OBJECT
   include/detail/aglGPUMemBlockMgr.h
   include/detail/aglMemoryPoolHeap.h
   include/detail/aglPrivateResource.h
+  include/detail/aglShaderHolder.h
   include/detail/aglSurface.h
 
   include/driver/aglGraphicsDriverMgr.h

--- a/include/common/aglShaderProgramArchive.h
+++ b/include/common/aglShaderProgramArchive.h
@@ -4,17 +4,11 @@
 #include <heap/seadDisposer.h>
 #include <hostio/seadHostIONode.h>
 #include <prim/seadSafeString.h>
+#include "common/aglResBinaryShaderArchive.h"
+#include "common/aglResShaderArchive.h"
 
 namespace agl {
 
-class ResBinaryShaderArchive {
-private:
-    void* mPtr;
-};
-class ResShaderArchive {
-private:
-    void* mPtr;
-};
 class ResShaderProgram;
 class ResShaderSource;
 class ShaderProgram;

--- a/include/common/aglShaderProgramArchive.h
+++ b/include/common/aglShaderProgramArchive.h
@@ -1,14 +1,25 @@
 #pragma once
 
+#include <container/seadBuffer.h>
 #include <heap/seadDisposer.h>
 #include <hostio/seadHostIONode.h>
+#include <prim/seadSafeString.h>
 
 namespace agl {
 
-class ResBinaryShaderArchive;
-class ResShaderArchive;
+class ResBinaryShaderArchive {
+private:
+    void* mPtr;
+};
+class ResShaderArchive {
+private:
+    void* mPtr;
+};
 class ResShaderProgram;
 class ResShaderSource;
+class ShaderProgram;
+class ShaderProgramEdit;
+class ShaderSource;
 
 class ShaderProgramArchive : public sead::IDisposer, public sead::hostio::Node {
 public:
@@ -22,11 +33,22 @@ public:
     void updateCompileInfo();
     void setUp();
     void setUp_(bool);
+    void setUpFromObjectReflector(bool, bool);
+    int searchShaderProgramIndex(const sead::SafeString&) const;
+    sead::FormatFixedSafeString<1024> genMessage(sead::hostio::Context* context);
+    void listenPropertyEvent(const sead::hostio::PropertyEvent* property_event);
 
 private:
-    void* _20;
-    ResBinaryShaderArchive* mBinaryShaderArchive;
-    ResShaderArchive* mResShaderArchive;
+    ResBinaryShaderArchive mBinaryShaderArchive;
+    ResShaderArchive mResShaderArchive;
+    sead::Buffer<ShaderProgram> mShaderPrograms;
+    void* _48[6];
+    short _78[2];
+    sead::Buffer<ShaderProgramEdit> mShaderProgramEdits;
+    sead::Buffer<ShaderSource> mShaderSources;
+    sead::Buffer<void*> unkData;
+    sead::Buffer<bool*> unkData2;
 };
+static_assert(sizeof(ShaderProgramArchive) == 0xC0);
 
 }  // namespace agl

--- a/include/detail/aglShaderHolder.h
+++ b/include/detail/aglShaderHolder.h
@@ -27,7 +27,7 @@ public:
 private:
     sead::FixedPtrArray<ShaderProgram, 206> mShaderPrograms;
     sead::UnsafeArray<ShaderProgramArchive, 6> mShaderProgramArchives;
-    char mArchiveOptions;
+    bool mArchiveOptions;
 };
 static_assert(sizeof(ShaderHolder) == 0xB30);
 

--- a/include/detail/aglShaderHolder.h
+++ b/include/detail/aglShaderHolder.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <heap/seadDisposer.h>
+#include <hostio/seadHostIOReflexible.h>
+#include <prim/seadSafeString.h>
+#include <resource/seadArchiveRes.h>
+#include "common/aglShaderProgramArchive.h"
+
+namespace agl {
+
+class ShaderProgram;
+
+namespace detail {
+
+class ShaderHolder {
+    SEAD_SINGLETON_DISPOSER(ShaderHolder);
+
+public:
+    ShaderHolder();
+    virtual ~ShaderHolder();
+
+    void initialize(sead::ArchiveRes* archiveRes, sead::Heap* heap);
+    sead::FormatFixedSafeString<1024> genMessage(sead::hostio::Context* context);
+    void listenPropertyEvent(const sead::hostio::PropertyEvent* property_event);
+
+private:
+    sead::FixedPtrArray<ShaderProgram, 206> mShaderPrograms;
+    sead::UnsafeArray<ShaderProgramArchive, 6> mShaderProgramArchives;
+    char mArchiveOptions;
+};
+static_assert(sizeof(ShaderHolder) == 0xB30);
+
+}  // namespace detail
+}  // namespace agl


### PR DESCRIPTION
Adding new file `detail/aglShaderHolder.h`, and pushing progress on `aglShaderProgramArchive.h` for that.

Inspired by `SuperMarioOdysseyOnline`: https://github.com/CraftyBoss/SuperMarioOdysseyOnline/blob/main/include/agl/detail/ShaderHolder.h

That information was only that `ShaderHolder` contains a `SEAD_SINGLETON_DISPOSER`, everything else has been researched from SMO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/13)
<!-- Reviewable:end -->
