### PR TITLE
common/DrawContext: Use `ShaderEnum` instead of stubbing own enum

### DIFF
--- a/include/common/aglDrawContext.h
+++ b/include/common/aglDrawContext.h
@@ -5,11 +5,12 @@
 #include <prim/seadRuntimeTypeInfo.h>
 #include <thread/seadCriticalSection.h>
 
+#include "common/aglShaderEnum.h"
+
 namespace agl {
 
 class RenderBuffer;
 class DisplayList;
-enum ShaderMode {};
 enum ShaderOptimizeType {};
 
 class DrawContext : public sead::DrawContext {


### PR DESCRIPTION
This is the first PR of a series of PRs across all libraries, which will try to fix more issues with the current headers by introducing a new workflow on the `OdysseyDecomp` repo. As of right now, trying to compile certain combinations of headers or singular headers individually will fail, due to a number of reasons: Duplicate definitions, stubs that should have been replaced by including their proper definition, includes missing altogether and maybe more.

This repo was pretty easy: Only the change listed below is required. As `ShaderMode` is defined as proper `enum` in `aglShaderEnum`, it should be included from there instead of defining it again, as this would lead to a compile error with "duplicate definition" otherwise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/16)
<!-- Reviewable:end -->
