### PR TITLE
g3d: Add `ResFile::Setup` function

### DIFF
--- a/include/g3d/aglNW4FToNN.h
+++ b/include/g3d/aglNW4FToNN.h
@@ -2,14 +2,13 @@
 
 namespace nn::g3d {
 class ResFile;
-}
+}  // namespace nn::g3d
 
 namespace agl::g3d {
-
 class ResFile {
 public:
+    static void Setup(nn::g3d::ResFile*);
     static void BindTexture(nn::g3d::ResFile*, nn::g3d::ResFile*);
     static void Cleanup(nn::g3d::ResFile*);
 };
-
 }  // namespace agl::g3d


### PR DESCRIPTION
This PR add `ResFile::Setup` function.

This function is needed for `Resource::tryCreateResGraphicsFile` in SMO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/17)
<!-- Reviewable:end -->
