### PR TITLE
common: Fix `GPUMemAddr` and `Block`

### DIFF
--- a/include/common/aglGPUMemAddr.h
+++ b/include/common/aglGPUMemAddr.h
@@ -10,6 +10,10 @@ class Heap;
 namespace agl {
 class GPUMemAddrBase {
 public:
+    GPUMemAddrBase() {}
+    GPUMemAddrBase(const GPUMemAddrBase& other, int alignmentOffset)
+        : mMemoryPool(other.mMemoryPool), mAlignmentAddr(other.mAlignmentAddr + alignmentOffset),
+          mMemoryBlock(other.mMemoryBlock) {}
     GPUMemAddrBase(const GPUMemBlockBase& memBlock, u64 offset);
 
     u32 verify_() const;
@@ -21,10 +25,12 @@ public:
     void flushCPUCache(u64);
     void invalidateCPUCache(u64);
 
+    bool isValid() const { return mMemoryPool != nullptr; }
+
 private:
-    detail::MemoryPool* mMemoryPool;
-    int mAlignmentAddr;
-    GPUMemBlockBase* mMemoryBlock;
+    detail::MemoryPool* mMemoryPool = nullptr;
+    int mAlignmentAddr = 0;
+    GPUMemBlockBase* mMemoryBlock = nullptr;
 };
 
 template <typename T>

--- a/include/common/aglGPUMemBlock.h
+++ b/include/common/aglGPUMemBlock.h
@@ -18,7 +18,7 @@ class MemoryPoolHeap;
 
 class GPUMemBlockBase {
 public:
-    explicit GPUMemBlockBase(sead::Heap* p_heap);
+    GPUMemBlockBase();
     virtual ~GPUMemBlockBase();
 
     void clear();

--- a/include/common/aglGPUMemBlock.h
+++ b/include/common/aglGPUMemBlock.h
@@ -52,7 +52,7 @@ static_assert(sizeof(GPUMemBlockBase) == 0x38);
 template <typename T>
 class GPUMemBlockT : public GPUMemBlockBase {
 public:
-    ~GPUMemBlockT() {;}
+    ~GPUMemBlockT() { ; }
 };
 
 // TODO

--- a/include/common/aglGPUMemBlock.h
+++ b/include/common/aglGPUMemBlock.h
@@ -52,7 +52,7 @@ static_assert(sizeof(GPUMemBlockBase) == 0x38);
 template <typename T>
 class GPUMemBlockT : public GPUMemBlockBase {
 public:
-    ~GPUMemBlockT() { ; }
+    ~GPUMemBlockT() override { ; }
 };
 
 // TODO

--- a/include/common/aglGPUMemBlock.h
+++ b/include/common/aglGPUMemBlock.h
@@ -50,7 +50,10 @@ static_assert(sizeof(GPUMemBlockBase) == 0x38);
 
 // TODO
 template <typename T>
-class GPUMemBlockT : public GPUMemBlockBase {};
+class GPUMemBlockT : public GPUMemBlockBase {
+public:
+    ~GPUMemBlockT() {;}
+};
 
 // TODO
 template <typename T>


### PR DESCRIPTION
Required for implementing `GpuMemAllocator` in SMO. Apparently, the arguments of `GPUMemBlockBase` have been wrong here - the function is invoked after the `sead::Heap*`-specific `operator new` is called, but it does not take the heap itself, according to symbols in SMO. I could not find any reference to this in BotW.

This causes no mismatches or compiler errors in BotW and SMO.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/18)
<!-- Reviewable:end -->
