### PR TITLE
common: Implement `ShaderLocation`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(agl OBJECT
   include/common/aglShader.h
   include/common/aglShaderCompileInfo.h
   include/common/aglShaderEnum.h
+  include/common/aglShaderLocation.h
   include/common/aglShaderProgram.h
   include/common/aglShaderProgramArchive.h
   include/common/aglTextureData.h
@@ -72,6 +73,8 @@ add_library(agl OBJECT
   include/utility/aglParameterStringMgr.h
   include/utility/aglResParameter.h
   include/utility/aglScreenShotMgr.h
+
+  src/common/aglShaderLocation.cpp
   
   src/detail/aglGPUMemBlockMgr.cpp
 

--- a/include/common/aglShader.h
+++ b/include/common/aglShader.h
@@ -16,6 +16,8 @@ public:
 
     void setBinary(const void* shaderBinary);
 
+    const void* getShaderBinary() const { return mShaderBinary; }
+
 private:
     void* mShaderBinary;  // _8
     void* _10;

--- a/include/common/aglShaderLocation.h
+++ b/include/common/aglShaderLocation.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadNamable.h>
+
+#include "common/aglShaderEnum.h"
+
+namespace agl {
+class ShaderProgram;
+
+class ShaderLocation {
+public:
+    void setLocation(s32);
+    void setLocation(ShaderType, s32);
+    void setRegisterLocation(ShaderType, s32);
+
+private:
+    union {
+        s8 mLocation[cShaderType_Num];
+        s16 mRegisterLocation[2];
+    };
+};
+
+class UniformBlockLocation : public ShaderLocation, public sead::INamable {
+    ~UniformBlockLocation();
+    void search(const ShaderProgram&);
+};
+
+}

--- a/include/common/aglShaderLocation.h
+++ b/include/common/aglShaderLocation.h
@@ -26,4 +26,4 @@ class UniformBlockLocation : public ShaderLocation, public sead::INamable {
     void search(const ShaderProgram&);
 };
 
-}
+}  // namespace agl

--- a/include/common/aglShaderLocation.h
+++ b/include/common/aglShaderLocation.h
@@ -22,7 +22,7 @@ private:
 };
 
 class UniformBlockLocation : public ShaderLocation, public sead::INamable {
-    ~UniformBlockLocation();
+    ~UniformBlockLocation() = default;
     void search(const ShaderProgram&);
 };
 

--- a/include/common/aglShaderProgram.h
+++ b/include/common/aglShaderProgram.h
@@ -3,6 +3,7 @@
 #include <prim/seadSafeString.h>
 #include "common/aglDisplayList.h"
 #include "common/aglShader.h"
+#include "common/aglShaderEnum.h"
 
 namespace sead {
 class Heap;
@@ -31,6 +32,9 @@ public:
                               sead::Heap*);
     void setVariationMacroValue(s32, s32, const sead::SafeString&);
     void createVariation(sead::Heap*);
+    bool hasStage(ShaderType) const;
+    const Shader& getShader(ShaderType) const;
+    Shader* getShader(ShaderType);
 
 private:
     u64* _8;

--- a/src/common/aglShaderLocation.cpp
+++ b/src/common/aglShaderLocation.cpp
@@ -1,0 +1,73 @@
+#include "common/aglShaderLocation.h"
+
+#include <cstring>
+
+#include "common/aglShaderProgram.h"
+
+namespace agl {
+
+void ShaderLocation::setLocation(s32 location) {
+    for (s32 i = 0; i < cShaderType_Num; ++i) {
+        mLocation[i] = location;
+    }
+}
+
+void ShaderLocation::setLocation(ShaderType type, s32 location) {
+    mLocation[type] = location;
+}
+
+void ShaderLocation::setRegisterLocation(ShaderType type, s32 location) {
+    mRegisterLocation[type != cShaderType_Vertex] = location;
+}
+
+UniformBlockLocation::~UniformBlockLocation() = default;
+
+static s32 getLocation(const UniformBlockLocation& loc, const ShaderProgram& program,
+                       ShaderType type) {
+    if (!program.hasStage(type))
+        return -1;
+
+    const Shader& shader = program.getShader(type);
+    const void* data = shader.getShaderBinary();
+    if (!data)
+        return -1;
+
+    // TODO: replace with proper types in headers
+    using UniformBlock = struct {
+        const char* name;
+        u32 location;
+    };
+    using ShaderBinary = struct {
+        u8 _0[0x14];
+        u32 numUniformBlocks;
+        UniformBlock* uniformBlocks;
+    };
+
+    const ShaderBinary* shaderBinary = reinterpret_cast<const ShaderBinary*>(data);
+    const char* name = loc.getName().cstr();
+    u32 numUniformBlocks = shaderBinary->numUniformBlocks;
+    if (numUniformBlocks == 0)
+        return -1;
+
+    UniformBlock* uniformBlocks = shaderBinary->uniformBlocks;
+
+    // TODO: probably an inlined search function returning UniformBlock*
+    for (u32 i = 0; i < numUniformBlocks; i++) {
+        if (strcmp(uniformBlocks[i].name, name) == 0) {
+            if (&uniformBlocks[i])
+                return uniformBlocks[i].location;
+            return -1;
+        }
+    }
+
+    return -1;
+}
+
+void UniformBlockLocation::search(const ShaderProgram& program) {
+    for (s32 i = 0; i < cShaderType_Num; ++i) {
+        ShaderType type = static_cast<ShaderType>(i);
+        setLocation(type, getLocation(*this, program, type));
+    }
+}
+
+}  // namespace agl

--- a/src/common/aglShaderLocation.cpp
+++ b/src/common/aglShaderLocation.cpp
@@ -20,15 +20,12 @@ void ShaderLocation::setRegisterLocation(ShaderType type, s32 location) {
     mRegisterLocation[type != cShaderType_Vertex] = location;
 }
 
-UniformBlockLocation::~UniformBlockLocation() = default;
-
 static s32 getLocation(const UniformBlockLocation& loc, const ShaderProgram& program,
                        ShaderType type) {
     if (!program.hasStage(type))
         return -1;
 
-    const Shader& shader = program.getShader(type);
-    const void* data = shader.getShaderBinary();
+    const void* data = program.getShader(type).getShaderBinary();
     if (!data)
         return -1;
 
@@ -49,14 +46,12 @@ static s32 getLocation(const UniformBlockLocation& loc, const ShaderProgram& pro
     if (numUniformBlocks == 0)
         return -1;
 
-    UniformBlock* uniformBlocks = shaderBinary->uniformBlocks;
-
     // TODO: probably an inlined search function returning UniformBlock*
     for (u32 i = 0; i < numUniformBlocks; i++) {
-        if (strcmp(uniformBlocks[i].name, name) == 0) {
-            if (&uniformBlocks[i])
-                return uniformBlocks[i].location;
-            return -1;
+        if (strcmp(shaderBinary->uniformBlocks[i].name, name) == 0) {
+            if (&shaderBinary->uniformBlocks[i])
+                return shaderBinary->uniformBlocks[i].location;
+            break;
         }
     }
 

--- a/src/common/aglShaderLocation.cpp
+++ b/src/common/aglShaderLocation.cpp
@@ -42,12 +42,9 @@ static s32 getLocation(const UniformBlockLocation& loc, const ShaderProgram& pro
 
     const ShaderBinary* shaderBinary = reinterpret_cast<const ShaderBinary*>(data);
     const char* name = loc.getName().cstr();
-    u32 numUniformBlocks = shaderBinary->numUniformBlocks;
-    if (numUniformBlocks == 0)
-        return -1;
 
     // TODO: probably an inlined search function returning UniformBlock*
-    for (u32 i = 0; i < numUniformBlocks; i++) {
+    for (u32 i = 0; i < shaderBinary->numUniformBlocks; i++) {
         if (strcmp(shaderBinary->uniformBlocks[i].name, name) == 0) {
             if (&shaderBinary->uniformBlocks[i])
                 return shaderBinary->uniformBlocks[i].location;


### PR DESCRIPTION
I felt like decompiling something today. @tetraxile recently posted some headers for these two classes into the discord, so why not take that as inspiration and persist them at the right location in the repo?

The `ShaderBinary` struct seems to be platform-specific - the Wii-specific repos use `GX2` variants there, which have a different layout. More research on the file format would need to be done, followed by properly adding that struct somewhere else - so I've kept it as `TODO` for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/21)
<!-- Reviewable:end -->
