### PR TITLE
utility: Remove explicit instances of ParameterBase

### DIFF
--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -414,23 +414,4 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
-// TODO: Remove these explicit instantiations once ParameterBase::createByTypeName is implemented.
-template class Parameter<bool>;
-template class Parameter<f32>;
-template class Parameter<s32>;
-template class Parameter<sead::Vector2f>;
-template class Parameter<sead::Vector3f>;
-template class Parameter<sead::Vector4f>;
-template class Parameter<sead::Color4f>;
-template class Parameter<sead::FixedSafeString<32>>;
-template class Parameter<sead::FixedSafeString<64>>;
-template class Parameter<sead::FixedSafeString<256>>;
-template class Parameter<sead::Quatf>;
-template class Parameter<u32>;
-template class Parameter<sead::SafeString>;
-template class ParameterCurve<1>;
-template class ParameterCurve<2>;
-template class ParameterCurve<3>;
-template class ParameterCurve<4>;
-
 }  // namespace agl::utl


### PR DESCRIPTION
This is not the correct way to force these functions to be compiled.  Currently it generates 230 functions that don't exist in SMO since they are are fully inlined and as such they have no symbol.

Unfortunately we don't make use of all ParameterBase types yet. So these types will need to be changed to NotDecompiled in both projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/22)
<!-- Reviewable:end -->
