### PR TITLE
utility: Implement `ParemeterBase::createByTypeName`

### DIFF
--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -10,7 +10,6 @@
 #include <math/seadQuat.h>
 #include <math/seadVector.h>
 #include <prim/seadSafeString.h>
-#include <prim/seadStringUtil.h>
 #include "utility/aglResParameter.h"
 
 namespace sead {
@@ -303,15 +302,12 @@ protected:
 template <typename T>
 class ParameterBuffer : public Parameter<T*> {
 public:
-    ParameterBuffer(sead::Heap* heap, const sead::SafeString& elements) {
+    ParameterBuffer() = default;
+
+    ~ParameterBuffer() override { freeBuffer(); }
+
+    void allocateBuffer(sead::Heap* heap, u32 num) {
         SEAD_ASSERT(!isBinaryInternalBuffer());
-        u32 num = sead::StringUtil::parseS32(elements, sead::StringUtil::CardinalNumber::BaseAuto);
-
-        // TODO: Check if this can be generalized for any type
-        if constexpr (std::is_same<T, u8>()) {
-            num = sead::Mathf::ceil(num * 0.25f) * 4;
-        }
-
         this->mValue = new (heap) T[num];
         mBufferSize = num;
         mBufferAllocated = true;
@@ -319,8 +315,6 @@ public:
         for (s32 i = 0; i < num; ++i)
             this->mValue[i] = {};
     }
-
-    ~ParameterBuffer() override { freeBuffer(); }
 
     void freeBuffer() {
         if (!mBufferAllocated)

--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -103,7 +103,7 @@ public:
     void applyString(const sead::SafeString& string, bool x);
     virtual void postApplyResource_(const void*, size_t) {}
     static ParameterBase* createByTypeName(const sead::SafeString& name,
-                                           const sead::SafeString& value);
+                                           const sead::SafeString& bufferSize);
 
     virtual bool isBinary() const { return false; }
     virtual bool isBinaryInternalBuffer() const { return true; }

--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -102,7 +102,8 @@ public:
     void applyResource(ResParameter res, f32 t);
     void applyString(const sead::SafeString& string, bool x);
     virtual void postApplyResource_(const void*, size_t) {}
-    ParameterBase* createByTypeName(const sead::SafeString& name, const sead::SafeString& value);
+    static ParameterBase* createByTypeName(const sead::SafeString& name,
+                                           const sead::SafeString& value);
 
     virtual bool isBinary() const { return false; }
     virtual bool isBinaryInternalBuffer() const { return true; }
@@ -371,6 +372,8 @@ public:
 template <u32 N>
 class ParameterCurve : public ParameterBase {
 public:
+    ParameterCurve() { reset(); }
+
     ParameterCurve(const sead::SafeString& name, const sead::SafeString& label,
                    IParameterObj* param_obj);
 

--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -313,7 +313,7 @@ public:
         mBufferSize = num;
         mBufferAllocated = true;
 
-        for (s32 i = 0; i < num; ++i)
+        for (u32 i = 0; i < num; ++i)
             this->mValue[i] = {};
     }
 

--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -10,6 +10,7 @@
 #include <math/seadQuat.h>
 #include <math/seadVector.h>
 #include <prim/seadSafeString.h>
+#include <prim/seadStringUtil.h>
 #include "utility/aglResParameter.h"
 
 namespace sead {
@@ -102,7 +103,7 @@ public:
     void applyResource(ResParameter res, f32 t);
     void applyString(const sead::SafeString& string, bool x);
     virtual void postApplyResource_(const void*, size_t) {}
-    void createByTypeName(const sead::SafeString& a, const sead::SafeString& b);
+    ParameterBase* createByTypeName(const sead::SafeString& name, const sead::SafeString& value);
 
     virtual bool isBinary() const { return false; }
     virtual bool isBinaryInternalBuffer() const { return true; }
@@ -302,8 +303,15 @@ protected:
 template <typename T>
 class ParameterBuffer : public Parameter<T*> {
 public:
-    ParameterBuffer(sead::Heap* heap, s32 num) {
+    ParameterBuffer(sead::Heap* heap, const sead::SafeString& elements) {
         SEAD_ASSERT(!isBinaryInternalBuffer());
+        u32 num = sead::StringUtil::parseS32(elements, sead::StringUtil::CardinalNumber::BaseAuto);
+
+        // TODO: Check if this can be generalized for any type
+        if constexpr (std::is_same<T, u8>()) {
+            num = sead::Mathf::ceil(num * 0.25f) * 4;
+        }
+
         this->mValue = new (heap) T[num];
         mBufferSize = num;
         mBufferAllocated = true;
@@ -343,7 +351,7 @@ public:
     void postApplyResource_(const void* data, size_t size) override {
         if (isBinaryInternalBuffer())
             return;
-        this->mValue = data;
+        this->mValue = const_cast<T*>(static_cast<const T*>(data));
         mBufferSize = size / sizeof(T);
     }
 

--- a/include/utility/aglParameterCurve.hpp
+++ b/include/utility/aglParameterCurve.hpp
@@ -13,6 +13,20 @@ inline ParameterCurve<N>::ParameterCurve(const sead::SafeString& name,
     reset();
 }
 
+// NOTE: This is a hack to match ParameterBase::createByTypeName. It doesn't inline using the
+// general template.
+template <>
+inline void ParameterCurve<4>::reset() {
+    static f32 s_initialize[9] = {0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 0.5};
+    for (s32 i = 0; i < 4; ++i) {
+        sead::MemUtil::copy(mCurveData[i].f, s_initialize, sizeof(s_initialize));
+        for (s32 j = 9; j < cUnitCurveParamNum; ++j)
+            mCurveData[i].f[j] = 1.0;
+        mCurves[i].setData(&mCurveData[i], sead::hostio::CurveType::Hermit2D, cUnitCurveParamNum,
+                           9);
+    }
+}
+
 template <u32 N>
 inline void ParameterCurve<N>::reset() {
     static f32 s_initialize[9] = {0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 0.5};

--- a/include/utility/aglParameterCurve.hpp
+++ b/include/utility/aglParameterCurve.hpp
@@ -18,9 +18,9 @@ inline ParameterCurve<N>::ParameterCurve(const sead::SafeString& name,
 template <>
 inline void ParameterCurve<4>::reset() {
     static f32 s_initialize[9] = {0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 0.5};
-    for (s32 i = 0; i < 4; ++i) {
+    for (u32 i = 0; i < 4; ++i) {
         sead::MemUtil::copy(mCurveData[i].f, s_initialize, sizeof(s_initialize));
-        for (s32 j = 9; j < cUnitCurveParamNum; ++j)
+        for (u32 j = 9; j < cUnitCurveParamNum; ++j)
             mCurveData[i].f[j] = 1.0;
         mCurves[i].setData(&mCurveData[i], sead::hostio::CurveType::Hermit2D, cUnitCurveParamNum,
                            9);
@@ -30,9 +30,9 @@ inline void ParameterCurve<4>::reset() {
 template <u32 N>
 inline void ParameterCurve<N>::reset() {
     static f32 s_initialize[9] = {0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 0.5};
-    for (s32 i = 0; i < N; ++i) {
+    for (u32 i = 0; i < N; ++i) {
         sead::MemUtil::copy(mCurveData[i].f, s_initialize, sizeof(s_initialize));
-        for (s32 j = 9; j < cUnitCurveParamNum; ++j)
+        for (u32 j = 9; j < cUnitCurveParamNum; ++j)
             mCurveData[i].f[j] = 1.0;
         mCurves[i].setData(&mCurveData[i], sead::hostio::CurveType::Hermit2D, cUnitCurveParamNum,
                            9);
@@ -59,7 +59,7 @@ inline void ParameterCurve<N>::copyUnsafe(const ParameterBase& other) {
     }
 
     sead::MemUtil::copy(ptr(), other.ptr(), size());
-    for (s32 i = 0; i < N; ++i) {
+    for (u32 i = 0; i < N; ++i) {
         auto& curve = mCurves[i];
         auto& curve_other = static_cast<const ParameterCurve<N>&>(other).mCurves[i];
         curve.setCurveType(curve_other.getCurveType());
@@ -91,14 +91,14 @@ inline ParameterBase* ParameterCurve<N>::clone(sead::Heap* heap, IParameterObj* 
 template <u32 N>
 inline void ParameterCurve<N>::postApplyResource_(const void*, size_t size) {
     if (this->size() == size) {
-        for (s32 i = 0; i < N; ++i) {
+        for (u32 i = 0; i < N; ++i) {
             mCurves[i].setCurveType(sead::hostio::CurveType(mCurveData[i].curveType));
             mCurves[i].mFloats = mCurveData[i].f;
             mCurves[i].mInfo.numFloats = cUnitCurveParamNum;
             mCurves[i].setNumUse(mCurveData[i].numUse);
         }
     } else {
-        for (s32 i = 0; i < N; ++i) {
+        for (u32 i = 0; i < N; ++i) {
             mCurves[i].mInfo.numFloats = cUnitCurveParamNum;
             mCurves[i].mFloats = mCurveData[i].f;
         }

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -414,4 +414,73 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
+// NON_MATCHING: https://decomp.me/scratch/46nZM
+ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
+                                               const sead::SafeString& value) {
+    if (name.isEqual(getParameterTypeName(ParameterType::Bool))) {
+        return new Parameter<bool>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::F32))) {
+        return new Parameter<f32>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Int))) {
+        return new Parameter<s32>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::U32))) {
+        return new Parameter<u32>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Vec2))) {
+        return new Parameter<sead::Vector2f>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Vec3))) {
+        return new Parameter<sead::Vector3f>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Vec4))) {
+        return new Parameter<sead::Vector4f>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Color))) {
+        return new Parameter<sead::Color4f>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Quat))) {
+        return new Parameter<sead::Quatf>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::String32))) {
+        return new Parameter<sead::FixedSafeString<32>>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::String64))) {
+        return new Parameter<sead::FixedSafeString<64>>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::String256))) {
+        return new Parameter<sead::FixedSafeString<256>>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::StringRef))) {
+        return new Parameter<sead::SafeString>;
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Curve1))) {
+        return new ParameterCurve<1>("", "", nullptr);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Curve2))) {
+        return new ParameterCurve<2>("", "", nullptr);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Curve3))) {
+        return new ParameterCurve<3>("", "", nullptr);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::Curve4))) {
+        return new ParameterCurve<4>("", "", nullptr);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::BufferInt))) {
+        return new ParameterBuffer<s32>(nullptr, value);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::BufferF32))) {
+        return new ParameterBuffer<f32>(nullptr, value);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::BufferU32))) {
+        return new ParameterBuffer<u32>(nullptr, value);
+    }
+    if (name.isEqual(getParameterTypeName(ParameterType::BufferBinary))) {
+        return new ParameterBuffer<u8>(nullptr, value);
+    }
+    return nullptr;
+}
+
 }  // namespace agl::utl

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -415,7 +415,7 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
-// NON_MATCHING: https://decomp.me/scratch/wBa6H
+// NON_MATCHING: https://decomp.me/scratch/N8MEk
 ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
                                                const sead::SafeString& value) {
     if (name.isEqual(getParameterTypeName(ParameterType::Bool))) {

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -415,7 +415,6 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
-// NON_MATCHING: https://decomp.me/scratch/N8MEk
 ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
                                                const sead::SafeString& value) {
     if (name.isEqual(getParameterTypeName(ParameterType::Bool))) {
@@ -458,16 +457,16 @@ ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
         return new Parameter<sead::SafeString>;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::Curve1))) {
-        return new ParameterCurve<1>("", "", nullptr);
+        return new ParameterCurve<1>;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::Curve2))) {
-        return new ParameterCurve<2>("", "", nullptr);
+        return new ParameterCurve<2>;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::Curve3))) {
-        return new ParameterCurve<3>("", "", nullptr);
+        return new ParameterCurve<3>;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::Curve4))) {
-        return new ParameterCurve<4>("", "", nullptr);
+        return new ParameterCurve<4>;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferInt))) {
         ParameterBuffer<s32>* buffer = new ParameterBuffer<s32>;
@@ -490,7 +489,7 @@ ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
     if (name.isEqual(getParameterTypeName(ParameterType::BufferBinary))) {
         ParameterBuffer<u8>* buffer = new ParameterBuffer<u8>;
         u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
-        buffer->allocateBuffer(nullptr, sead::Mathf::ceil(num * 0.25f) * 4);
+        buffer->allocateBuffer(nullptr, (u32)sead::Mathf::ceil(num * 0.25f) * 4);
         return buffer;
     }
     return nullptr;

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -416,7 +416,7 @@ bool ParameterBase::makeZero() {
 }
 
 ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
-                                               const sead::SafeString& value) {
+                                               const sead::SafeString& bufferSize) {
     if (name.isEqual(getParameterTypeName(ParameterType::Bool))) {
         return new Parameter<bool>;
     }
@@ -470,26 +470,30 @@ ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferInt))) {
         ParameterBuffer<s32>* buffer = new ParameterBuffer<s32>;
-        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
-        buffer->allocateBuffer(nullptr, num);
+        u32 size =
+            sead::StringUtil::parseS32(bufferSize, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, size);
         return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferF32))) {
         ParameterBuffer<f32>* buffer = new ParameterBuffer<f32>;
-        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
-        buffer->allocateBuffer(nullptr, num);
+        u32 size =
+            sead::StringUtil::parseS32(bufferSize, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, size);
         return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferU32))) {
         ParameterBuffer<u32>* buffer = new ParameterBuffer<u32>;
-        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
-        buffer->allocateBuffer(nullptr, num);
+        u32 size =
+            sead::StringUtil::parseS32(bufferSize, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, size);
         return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferBinary))) {
         ParameterBuffer<u8>* buffer = new ParameterBuffer<u8>;
-        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
-        buffer->allocateBuffer(nullptr, (u32)sead::Mathf::ceil(num * 0.25f) * 4);
+        u32 size =
+            sead::StringUtil::parseS32(bufferSize, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, (u32)sead::Mathf::ceil(size * 0.25f) * 4);
         return buffer;
     }
     return nullptr;

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -5,6 +5,7 @@
 #include <math/seadVector.h>
 #include <prim/seadFormatPrint.h>
 #include <prim/seadMemUtil.h>
+#include <prim/seadStringUtil.h>
 #include "utility/aglParameterObj.h"
 #include "utility/aglParameterStringMgr.h"
 
@@ -414,7 +415,7 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
-// NON_MATCHING: https://decomp.me/scratch/46nZM
+// NON_MATCHING: https://decomp.me/scratch/wBa6H
 ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
                                                const sead::SafeString& value) {
     if (name.isEqual(getParameterTypeName(ParameterType::Bool))) {
@@ -469,16 +470,28 @@ ParameterBase* ParameterBase::createByTypeName(const sead::SafeString& name,
         return new ParameterCurve<4>("", "", nullptr);
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferInt))) {
-        return new ParameterBuffer<s32>(nullptr, value);
+        ParameterBuffer<s32>* buffer = new ParameterBuffer<s32>;
+        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, num);
+        return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferF32))) {
-        return new ParameterBuffer<f32>(nullptr, value);
+        ParameterBuffer<f32>* buffer = new ParameterBuffer<f32>;
+        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, num);
+        return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferU32))) {
-        return new ParameterBuffer<u32>(nullptr, value);
+        ParameterBuffer<u32>* buffer = new ParameterBuffer<u32>;
+        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, num);
+        return buffer;
     }
     if (name.isEqual(getParameterTypeName(ParameterType::BufferBinary))) {
-        return new ParameterBuffer<u8>(nullptr, value);
+        ParameterBuffer<u8>* buffer = new ParameterBuffer<u8>;
+        u32 num = sead::StringUtil::parseS32(value, sead::StringUtil::CardinalNumber::BaseAuto);
+        buffer->allocateBuffer(nullptr, sead::Mathf::ceil(num * 0.25f) * 4);
+        return buffer;
     }
     return nullptr;
 }

--- a/src/utility/aglParameter.cpp
+++ b/src/utility/aglParameter.cpp
@@ -414,23 +414,4 @@ bool ParameterBase::makeZero() {
     return false;
 }
 
-// TODO: Remove these explicit instantiations once ParameterBase::createByTypeName is implemented.
-template class Parameter<bool>;
-template class Parameter<f32>;
-template class Parameter<s32>;
-template class Parameter<sead::Vector2f>;
-template class Parameter<sead::Vector3f>;
-template class Parameter<sead::Vector4f>;
-template class Parameter<sead::Color4f>;
-template class Parameter<sead::FixedSafeString<32>>;
-template class Parameter<sead::FixedSafeString<64>>;
-template class Parameter<sead::FixedSafeString<256>>;
-template class Parameter<sead::Quatf>;
-template class Parameter<u32>;
-template class Parameter<sead::SafeString>;
-template class ParameterCurve<1>;
-template class ParameterCurve<2>;
-template class ParameterCurve<3>;
-template class ParameterCurve<4>;
-
 }  // namespace agl::utl


### PR DESCRIPTION
Supersedes #22 by implementing the actual function. This has the same effect as previous PR but keeps all the previous matches intact and adds 77 new matches. ~~This also removes a hack with ParameterCurve that for some reason was added to the header.~~

~~The function itself is not matching but really close. Most differences are in `ParameterCurve` and `ParameterBuffer` initialization. The inlining here is a killer, ghidra doesn't want to assign the correct types, the branching is chaos and reading asm is not fun in a function with this size.~~ Fixed!

I will keep working on it but I don't expect any significant improvements in a few weeks.


https://decomp.me/scratch/N8MEk

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/23)
<!-- Reviewable:end -->
