### PR TITLE
utility: Fix `Parameter::writeToXML` to `const`

### DIFF
--- a/include/utility/aglParameter.h
+++ b/include/utility/aglParameter.h
@@ -86,7 +86,7 @@ public:
                                               const sead::hostio::PropertyEvent* event);
 #endif
 
-    virtual void writeToXML(sead::XmlElement* element, sead::Heap* heap);
+    virtual void writeToXML(sead::XmlElement* element, sead::Heap* heap) const;
     virtual bool readFromXML(const sead::XmlElement& element, bool x);
 
     virtual ParameterType getParameterType() const = 0;
@@ -377,7 +377,7 @@ public:
     bool copy(const ParameterBase& other) override;
     void copyUnsafe(const ParameterBase& other) override;
 
-    void writeToXML(sead::XmlElement* element, sead::Heap* heap) override;
+    void writeToXML(sead::XmlElement* element, sead::Heap* heap) const override;
     bool readFromXML(const sead::XmlElement& element, bool x) override;
 
     ParameterType getParameterType() const override;


### PR DESCRIPTION
Currently not implemented, so this mistake hasn't been obvious before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/24)
<!-- Reviewable:end -->
