### PR TITLE
detail: Fix size of `GPUMemBlockMgrHeapEx` in SMM2

### DIFF
--- a/include/detail/aglGPUMemBlockMgr.h
+++ b/include/detail/aglGPUMemBlockMgr.h
@@ -64,7 +64,11 @@ private:
     void* m10;
     sead::CriticalSection mCS;
 };
+#if not SEAD_HOSTIO_NONVIRTUAL
 static_assert(sizeof(GPUMemBlockMgrHeapEx) == 0x80);
+#else
+static_assert(sizeof(GPUMemBlockMgrHeapEx) == 0x78);
+#endif
 
 enum class GPUMemBlockMgrFlags : u8 {
     MemoryPoolRelated = 1 << 0,


### PR DESCRIPTION
Follow-up PR to `sead`'s https://github.com/open-ead/sead/pull/273.

As `sead::hostio::Node` has now no size anymore, the entire class is shrinked by 8 bytes - without this change, it currently results in a compiler error.
This new size can be verified in the `operator new` call at `71002E92B0` within SMM2 v3.0.3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/agl/26)
<!-- Reviewable:end -->
